### PR TITLE
Fix hamburger button, add empty indicators

### DIFF
--- a/public/css/output.css
+++ b/public/css/output.css
@@ -2350,6 +2350,10 @@ section {
   height: 2rem;
 }
 
+.h-32 {
+  height: 8rem;
+}
+
 .w-full {
   width: 100%;
 }
@@ -2680,6 +2684,10 @@ section {
 
 .text-center {
   text-align: center;
+}
+
+.align-middle {
+  vertical-align: middle;
 }
 
 .text-6xl {

--- a/public/js/scripts.js
+++ b/public/js/scripts.js
@@ -1,18 +1,20 @@
-const mobileButtonHamburger = document.getElementById('hamburger-button')
-const mobileButtonX = document.getElementById('x-button')
-const mobileMenu = document.getElementById('mobile-menu')
+const mobileMenuButton = document.getElementById('mobile-menu-button');
+const mobileSymbolHamburger = document.getElementById('hamburger-symbol');
+const mobileSymbolX = document.getElementById('x-symbol');
+const mobileMenu = document.getElementById('mobile-menu');
 
-const hamburgerChange = () => {
-    mobileButtonHamburger.classList.add('hidden');
-    mobileButtonX.classList.remove('hidden');
-    mobileMenu.classList.remove('hidden');
+const hamburgerToggle = () => {
+    if(!mobileSymbolHamburger.classList.contains('hidden')) {
+        mobileSymbolHamburger.classList.add('hidden');
+        mobileSymbolX.classList.remove('hidden');
+        mobileMenu.classList.remove('hidden');
+    } else if (mobileSymbolHamburger.classList.contains('hidden')) {
+        mobileSymbolHamburger.classList.remove('hidden');
+        mobileSymbolX.classList.add('hidden');
+        mobileMenu.classList.add('hidden');
+    } else {
+        console.log("Mobile menu button exception.")
+    }
 }
 
-const xChange = () => {
-    mobileButtonX.classList.add('hidden');
-    mobileButtonHamburger.classList.remove('hidden');
-    mobileMenu.classList.add('hidden');
-}
-
-mobileButtonHamburger.addEventListener('click', hamburgerChange);
-mobileButtonX.addEventListener('click', xChange);
+mobileMenuButton.addEventListener('click', hamburgerToggle);

--- a/views/account.ejs
+++ b/views/account.ejs
@@ -69,6 +69,13 @@
           </tr>
         </thead>
         <tbody>
+          <% if(!transactions.length) { %>
+            <tr>
+              <td colspan="6">
+                <p class="text-center">No transactions found.</p>
+              </td>
+            </tr>
+          <% } %>
           <% for(var i=0; i < transactions.length; i++) { %>          
             <tr>
               <td><%= transactions[i].date %></td>

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -120,6 +120,13 @@
             </tr>
         </thead>
         <tbody>
+          <% if(!transactions.length) { %>
+            <tr>
+              <td colspan="6">
+                <p class="text-center">No transactions found.</p>
+              </td>
+            </tr>
+          <% } %>
           <% for(var i=0; i < transactions.length; i++) { %>          
             <tr>
               <td><%= transactions[i].date %></td>

--- a/views/entity.ejs
+++ b/views/entity.ejs
@@ -99,6 +99,13 @@
           </tr>
         </thead>
         <tbody>
+          <% if(!transactions.length) { %>
+            <tr>
+              <td colspan="6">
+                <p class="text-center">No transactions found.</p>
+              </td>
+            </tr>
+          <% } %>
           <% for(var i=0; i < transactions.length; i++) { %>          
             <tr>
               <td><%= transactions[i].date %></td>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -16,7 +16,7 @@
             <div class="absolute inset-y-0 left-0 flex items-center sm:hidden">
               <!-- Mobile menu button-->
               <% if(typeof user === 'object' && user) { %>
-              <button  type="button" class="inline-flex items-center justify-center rounded-md p-2 text-base-300 hover:bg-primary-focus hover:text-base-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white" aria-controls="mobile-menu" aria-expanded="false">
+              <button id="mobile-menu-button" type="button" class="inline-flex items-center justify-center rounded-md p-2 text-base-300 hover:bg-primary-focus hover:text-base-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white" aria-controls="mobile-menu" aria-expanded="false">
                 <span class="sr-only">Open main menu</span>
                 <!--
                   Icon when menu is closed.
@@ -25,7 +25,7 @@
       
                   Menu open: "hidden", Menu closed: "block"
                 -->
-                <svg id="hamburger-button" class="block h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                <svg id="hamburger-symbol" class="block h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
                 </svg>
                 <!--
@@ -35,7 +35,7 @@
       
                   Menu open: "block", Menu closed: "hidden"
                 -->
-                <svg id="x-button" class="hidden h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                <svg id="x-symbol" class="hidden h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
                 </svg>
               </button>

--- a/views/transaction.ejs
+++ b/views/transaction.ejs
@@ -40,12 +40,6 @@
         </tbody>
       </table>
     </section>
-    <!-- <div class="col-12 col-md-6 mt-3">
-      <h5>Description</h5>
-      <div class="border border-slate-300 rounded">
-        <p class="m-2"><%= transaction.description %></p>
-      </div>
-    </div> -->
     <header>
       <h2 class="section-title">Update Transaction</h2>
     </header>
@@ -125,9 +119,15 @@
               <span class="label-text">Documentation</span>
             </label>
             <div class="border rounded-lg w-full">
+              <% if(!transaction.imageURL) { %>
+                <div class="bg-base-200 flex justify-center items-center h-32">
+                  <p>Empty</p>
+                </div>
+              <% } else { %>
               <a href="<%= transaction.imageURL %>">
                 <img class="border rounded-lg max-w-sm mx-auto" src="<%= transaction.imageURL %>">
               </a>
+              <% } %>
             </div>
           </div>
           <div class="form-control col-span-12 sm:col-span-6">  


### PR DESCRIPTION
44417f6 - fixes #2 
- Adds EJS blocks to views which indicate a given table or document field is empty when the query result's length is zero

0c25d07 - fixes #1 
- Modifies client-side JS script to toggle mobile button SVG and mobile menu visibility, instead of having separate functions for showing and hiding.
- Ties the new function to the button element, instead of one function to each SVG.
- Adjusts header element ID's to make more sense.

-output.css updated to include height for document field empty indicator